### PR TITLE
fix: removed scroll from profile page

### DIFF
--- a/front/fire-station/src/components/Sidebar.vue
+++ b/front/fire-station/src/components/Sidebar.vue
@@ -85,6 +85,7 @@ export default {
 <style scoped>
 .sidebar__nav {
   padding-top: 30px;
+  box-sizing: border-box;
   min-width: 170px;
   width: 20vw;
   height: 100vh;

--- a/front/fire-station/src/components/UserData.vue
+++ b/front/fire-station/src/components/UserData.vue
@@ -71,8 +71,10 @@ export default {
 <style scoped>
 .profile {
   position: relative;
+  box-sizing: border-box;
   margin: 24px;
   min-width: 70vw;
+  width: 100%;
   min-height: 90vh;
   background: #fff;
   padding: 24px;


### PR DESCRIPTION
Со страницы профиля убран скролл, который появлялся из-за неправильного css в sidebar и profiledata